### PR TITLE
Improve render performance of pixel grid a bit

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -7,12 +7,14 @@ import HomePage from "../pages/HomePage";
 import HelpPage from "../pages/HelpPage";
 import { useTheme } from "../hooks/useTheme";
 import { useWindow } from "../hooks/useWindow";
-import { useScreen } from "../hooks/useScreen";
+import { ScreenState, useStore } from "../hooks/useScreen";
 import theme from "../theme";
+
+const selector = (state: ScreenState) => ({width: state.width, height: state.height, aspectRatio: state.aspectRatio});
 
 function App() {
   const { grayscale } = useTheme();
-  const { width, height, aspectRatio } = useScreen();
+  const { width, height, aspectRatio } = useStore(selector);
   const window = useWindow();
   const screen = { width, height, aspectRatio };
 

--- a/src/components/ClearButton.tsx
+++ b/src/components/ClearButton.tsx
@@ -1,8 +1,10 @@
 import { Button } from "./Button";
-import { useScreen } from "../hooks/useScreen";
+import { ScreenState, useStore } from "../hooks/useScreen";
+
+const selector = (state: ScreenState) => state.clearPixels;
 
 export const ClearButton = () => {
-  const { clearPixels } = useScreen();
+  const clearPixels = useStore(selector);
 
   const clearWithConfirm = () => {
     const confirmed = window.confirm("Are you sure?");

--- a/src/components/ExportButton.tsx
+++ b/src/components/ExportButton.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import ReactDomServer from "react-dom/server";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { Button } from "./Button";
-import { useScreen } from "../hooks/useScreen";
+import { ScreenState, useStore } from "../hooks/useScreen";
 
 export const ExportButton = () => {
   const [copied, setCopied] = useState(false);
@@ -30,8 +30,11 @@ export const ExportButton = () => {
   );
 };
 
+const selector = (state: ScreenState) => ({width: state.width, height: state.height, pixelsMatrix: state.pixels});
+
 const Screen = () => {
-  const { width, height, pixels } = useScreen();
+  const { width, height, pixelsMatrix } = useStore(selector);
+  const pixels = pixelsMatrix.reduce((acc, row) => [...acc, ...row], []);
 
   return (
     <svg viewBox={`0 0 ${width} ${height}`} xmlns="http://www.w3.org/2000/svg">

--- a/src/components/MintButton.tsx
+++ b/src/components/MintButton.tsx
@@ -9,6 +9,9 @@ export const MintButton = () => {
   const { send, state, encode256 } = useMint();
   const { screencode } = useScreen();
   const onClick = () => {
+    if (!screencode) {
+      return;
+    }
     const leftPart = encode256(screencode.leftCode);
     const rightPart = encode256(screencode.rightCode);
     console.log(screencode.leftCode, leftPart);

--- a/src/components/Screen.tsx
+++ b/src/components/Screen.tsx
@@ -1,56 +1,55 @@
+import React, { useCallback } from "react";
 import styled from "styled-components";
 import { useScreen } from "../hooks/useScreen";
 
+interface PixelGridProps {
+  width: number;
+  height: number;
+  pixelsMatrix: Pixel[][];
+
+  onPixelClick: (pixel: Pixel) => void;
+  onMouseEnter: (pixel: Pixel) => void;
+  onMouseDown: (pixel: Pixel) => void;
+}
+
+
+const PixelGrid = React.memo(function PixelGrid ({width, height, pixelsMatrix, onPixelClick, onMouseDown, onMouseEnter}: PixelGridProps) {
+  const pixels = pixelsMatrix.reduce((acc, row) => [...acc, ...row], []);
+  return (<SVG viewBox={`0 0 ${width} ${height}`} xmlns="http://www.w3.org/2000/svg">
+  <Background width={width} height={height} />
+  {pixels.map((pixel, i) => {
+    return (
+      <Pixel
+        key={i}
+        width={1.1}
+        height={1.1}
+        x={pixel.x}
+        y={pixel.y}
+        onClick={() => onPixelClick(pixel)}
+        onMouseEnter={() => onMouseEnter(pixel)}
+        onMouseDown={() => onMouseDown(pixel)}
+        isOn={pixel.on}
+      />
+    );
+  })}
+</SVG>)
+});
+
+const noop = () => {};
+
 export const Screen = () => {
   const {
-    width,
-    height,
-    pixels,
     togglePixel,
-    onPixelDown,
+    setLastPixelDown,
     onPixelEnter,
-    onPixelLeave,
+    height,
+    width,
+    pixels
   } = useScreen();
-  const onMouseDown = (pixel: Pixel) => () => onPixelDown(pixel);
-  const onMouseEnter = (pixel: Pixel) => () => onPixelEnter(pixel);
-  const onMouseLeave = (pixel: Pixel) => () => onPixelLeave(pixel);
-  const onPixelClick = (pixel: Pixel) => () => togglePixel(pixel);
+  const onMouseEnter = useCallback((pixel: Pixel) => onPixelEnter(pixel), [onPixelEnter]);
+  const onPixelClick = useCallback((pixel: Pixel) => togglePixel(pixel), [togglePixel]);
 
-  return (
-    <SVG viewBox={`0 0 ${width} ${height}`} xmlns="http://www.w3.org/2000/svg">
-      <Background width={width} height={height} />
-      {pixels.map((pixel, i) => {
-        return (
-          <Pixel
-            key={i}
-            width={1.1}
-            height={1.1}
-            x={pixel.x}
-            y={pixel.y}
-            onClick={onPixelClick(pixel)}
-            onMouseEnter={onMouseEnter(pixel)}
-            onMouseLeave={onMouseLeave(pixel)}
-            onMouseDown={onMouseDown(pixel)}
-            isOn={pixel.on}
-          />
-        );
-      })}
-      {/* <rect
-        SCREENwidth="3"
-        SCREENheight="3"
-        x={width - 3}
-        y={height - 3}
-        style={style.background}
-      />
-      <rect
-        SCREENwidth="1"
-        SCREENheight="1"
-        x={width - 2}
-        y={height - 2}
-        style={style.on}
-      /> */}
-    </SVG>
-  );
+return <PixelGrid height={height} width={width} pixelsMatrix={pixels} onMouseDown={setLastPixelDown} onMouseEnter={onMouseEnter} onPixelClick={onPixelClick} />
 };
 
 const SVG = styled.svg`

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,5 +5,4 @@ type Pixel = {
   x: number;
   y: number;
   on: boolean;
-  hovered: boolean;
 };

--- a/src/hooks/useScreen.ts
+++ b/src/hooks/useScreen.ts
@@ -6,7 +6,8 @@ import { BigNumber } from "ethers";
 export const SCREENWIDTH = 24;
 export const SCREENHEIGHT = 16;
 
-type ScreenState = {
+
+export type ScreenState = {
   width: number;
   height: number;
   aspectRatio: number;
@@ -17,12 +18,11 @@ type ScreenState = {
   updatePixel: (pixel: Pixel, update: Pixel) => void;
   setLastPixelDown: (pixel: Pixel) => void;
   togglePixel: (pixel: Pixel) => void;
-  setHovered: (pixel: Pixel, hovered: boolean) => void;
   setMouseDown: (isMouseDown: boolean) => void;
   clearPixels: () => void;
 };
 
-const useStore = create<ScreenState>(
+export const useStore = create<ScreenState>(
   persist(
     (set) => {
       const width = SCREENWIDTH;
@@ -59,8 +59,6 @@ const useStore = create<ScreenState>(
           set((state) => ({ lastPixelDown: pixel })),
         togglePixel: (pixel: Pixel) =>
           updatePixel(pixel, { ...pixel, on: !pixel.on }),
-        setHovered: (pixel: Pixel, hovered: boolean) =>
-          updatePixel(pixel, { ...pixel, hovered }),
         setMouseDown: (isMouseDown: boolean) =>
           set((state) => ({ isMouseDown })),
         clearPixels: () => {
@@ -75,30 +73,24 @@ const useStore = create<ScreenState>(
   )
 );
 
-export const useScreen = () => {
+export const useScreen = (shouldReturnCode: boolean = false) => {
   const store = useStore((state) => {
-    const pixelsMatrix = state.pixels;
-    const pixels = pixelsMatrix.reduce((acc, row) => [...acc, ...row], []);
-    const onPixelDown = (pixel: Pixel) => state.setLastPixelDown(pixel);
-    const onPixelLeave = (pixel: Pixel) => state.setHovered(pixel, false);
     const onPixelEnter = (pixel: Pixel) => {
       state.isMouseDown
-        ? state.updatePixel(pixel, {
+        && state.updatePixel(pixel, {
             ...pixel,
-            hovered: true,
             on: !state.lastPixelDown?.on,
           })
-        : state.setHovered(pixel, true);
     };
-    const screencode = gridToPairOfUint160(state.pixels);
+    let screencode = undefined;
+    if (shouldReturnCode) {
+      screencode = gridToPairOfUint160(state.pixels);
+    }
     return {
       ...state,
       screencode,
-      pixels,
-      pixelsMatrix,
-      onPixelDown,
+      pixels: state.pixels,
       onPixelEnter,
-      onPixelLeave,
     };
   });
 


### PR DESCRIPTION
These fixes are a little hacky but it's def faster - especially hovers. Note there is a bug that's more obvious now: when you click to start a drag the first pixel doesn't get filled 

- Only calculate screencode from pixels during export (biggest cost rn)
- Remove all hover state logic since I think it was being used to render the hover style but was moved to CSS
- Memoize pixel grid component to minimize render passes (it's still happening too often because callback refs are changing though)
- Read from zustand store directly in all components except `Screen` to prevent unneeded re-renders (especially during clicks caught by global handlers)
- Moved `pixelMatrix` flattening to leaf component so the `pixel` ref doesn't change on every render